### PR TITLE
fix: use falsy for accounts in computeIsActive

### DIFF
--- a/packages/core/src/hooks.ts
+++ b/packages/core/src/hooks.ts
@@ -51,7 +51,7 @@ export function initializeConnector<T extends Connector>(
 }
 
 function computeIsActive({ chainId, accounts, activating }: Web3ReactState) {
-  return Boolean(chainId && accounts && !activating)
+  return Boolean(chainId && accounts?.length && !activating)
 }
 
 /**

--- a/packages/core/src/hooks.ts
+++ b/packages/core/src/hooks.ts
@@ -51,7 +51,7 @@ export function initializeConnector<T extends Connector>(
 }
 
 function computeIsActive({ chainId, accounts, activating }: Web3ReactState) {
-  return Boolean(chainId && accounts?.length && !activating)
+  return chainId && accounts?.length && !activating
 }
 
 /**


### PR DESCRIPTION
Empty array [] is not falsy in Javascript, so Boolean([]) would return true. But we want `computeIsActive` to return false if accounts array is empty.