### PR TITLE
fix(example-next): update urls for passing type checking

### DIFF
--- a/packages/example-next/chains.ts
+++ b/packages/example-next/chains.ts
@@ -46,51 +46,51 @@ export function getAddChainParameters(chainId: number): AddEthereumChainParamete
 export const CHAINS: { [chainId: number]: BasicChainInformation | ExtendedChainInformation } = {
   1: {
     urls: [
-      process.env.infuraKey ? `https://mainnet.infura.io/v3/${process.env.infuraKey}` : undefined,
-      process.env.alchemyKey ? `https://eth-mainnet.alchemyapi.io/v2/${process.env.alchemyKey}` : undefined,
+      process.env.infuraKey ? `https://mainnet.infura.io/v3/${process.env.infuraKey}` : '',
+      process.env.alchemyKey ? `https://eth-mainnet.alchemyapi.io/v2/${process.env.alchemyKey}` : '',
       'https://cloudflare-eth.com',
-    ].filter((url) => url !== undefined),
+    ].filter((url) => url !== ''),
     name: 'Mainnet',
   },
   3: {
-    urls: [process.env.infuraKey ? `https://ropsten.infura.io/v3/${process.env.infuraKey}` : undefined].filter(
-      (url) => url !== undefined
+    urls: [process.env.infuraKey ? `https://ropsten.infura.io/v3/${process.env.infuraKey}` : ''].filter(
+      (url) => url !== ''
     ),
     name: 'Ropsten',
   },
   4: {
-    urls: [process.env.infuraKey ? `https://rinkeby.infura.io/v3/${process.env.infuraKey}` : undefined].filter(
-      (url) => url !== undefined
+    urls: [process.env.infuraKey ? `https://rinkeby.infura.io/v3/${process.env.infuraKey}` : ''].filter(
+      (url) => url !== ''
     ),
     name: 'Rinkeby',
   },
   5: {
-    urls: [process.env.infuraKey ? `https://goerli.infura.io/v3/${process.env.infuraKey}` : undefined].filter(
-      (url) => url !== undefined
+    urls: [process.env.infuraKey ? `https://goerli.infura.io/v3/${process.env.infuraKey}` : ''].filter(
+      (url) => url !== ''
     ),
     name: 'Görli',
   },
   42: {
-    urls: [process.env.infuraKey ? `https://kovan.infura.io/v3/${process.env.infuraKey}` : undefined].filter(
-      (url) => url !== undefined
+    urls: [process.env.infuraKey ? `https://kovan.infura.io/v3/${process.env.infuraKey}` : ''].filter(
+      (url) => url !== ''
     ),
     name: 'Kovan',
   },
   // Optimism
   10: {
     urls: [
-      process.env.infuraKey ? `https://optimism-mainnet.infura.io/v3/${process.env.infuraKey}` : undefined,
+      process.env.infuraKey ? `https://optimism-mainnet.infura.io/v3/${process.env.infuraKey}` : '',
       'https://mainnet.optimism.io',
-    ].filter((url) => url !== undefined),
+    ].filter((url) => url !== ''),
     name: 'Optimism',
     nativeCurrency: ETH,
     blockExplorerUrls: ['https://optimistic.etherscan.io'],
   },
   69: {
     urls: [
-      process.env.infuraKey ? `https://optimism-kovan.infura.io/v3/${process.env.infuraKey}` : undefined,
+      process.env.infuraKey ? `https://optimism-kovan.infura.io/v3/${process.env.infuraKey}` : '',
       'https://kovan.optimism.io',
-    ].filter((url) => url !== undefined),
+    ].filter((url) => url !== ''),
     name: 'Optimism Kovan',
     nativeCurrency: ETH,
     blockExplorerUrls: ['https://kovan-optimistic.etherscan.io'],
@@ -98,18 +98,18 @@ export const CHAINS: { [chainId: number]: BasicChainInformation | ExtendedChainI
   // Arbitrum
   42161: {
     urls: [
-      process.env.infuraKey ? `https://arbitrum-mainnet.infura.io/v3/${process.env.infuraKey}` : undefined,
+      process.env.infuraKey ? `https://arbitrum-mainnet.infura.io/v3/${process.env.infuraKey}` : '',
       'https://arb1.arbitrum.io/rpc',
-    ].filter((url) => url !== undefined),
+    ].filter((url) => url !== ''),
     name: 'Arbitrum One',
     nativeCurrency: ETH,
     blockExplorerUrls: ['https://arbiscan.io'],
   },
   421611: {
     urls: [
-      process.env.infuraKey ? `https://arbitrum-rinkeby.infura.io/v3/${process.env.infuraKey}` : undefined,
+      process.env.infuraKey ? `https://arbitrum-rinkeby.infura.io/v3/${process.env.infuraKey}` : '',
       'https://rinkeby.arbitrum.io/rpc',
-    ].filter((url) => url !== undefined),
+    ].filter((url) => url !== ''),
     name: 'Arbitrum Testnet',
     nativeCurrency: ETH,
     blockExplorerUrls: ['https://testnet.arbiscan.io'],
@@ -117,16 +117,16 @@ export const CHAINS: { [chainId: number]: BasicChainInformation | ExtendedChainI
   // Polygon
   137: {
     urls: [
-      process.env.infuraKey ? `https://polygon-mainnet.infura.io/v3/${process.env.infuraKey}` : undefined,
+      process.env.infuraKey ? `https://polygon-mainnet.infura.io/v3/${process.env.infuraKey}` : '',
       'https://polygon-rpc.com',
-    ].filter((url) => url !== undefined),
+    ].filter((url) => url !== ''),
     name: 'Polygon Mainnet',
     nativeCurrency: MATIC,
     blockExplorerUrls: ['https://polygonscan.com'],
   },
   80001: {
-    urls: [process.env.infuraKey ? `https://polygon-mumbai.infura.io/v3/${process.env.infuraKey}` : undefined].filter(
-      (url) => url !== undefined
+    urls: [process.env.infuraKey ? `https://polygon-mumbai.infura.io/v3/${process.env.infuraKey}` : ''].filter(
+      (url) => url !== ''
     ),
     name: 'Polygon Mumbai',
     nativeCurrency: MATIC,


### PR DESCRIPTION
When in `tsconfig` we have option `strict` to `true`, we get this type error for the chains urls:

```
Type '(string | undefined)[]' is not assignable to type 'string[]'.
  Type 'string | undefined' is not assignable to type 'string'.

```

switching to empty string instead of the `undefined` fix the issue.

PS: currently, in this project we do not have `strict` option, but nevertheless nice to have a correct typings.

