### PR TITLE
Fix network switch bug for generic EIP-1193 providers

### DIFF
--- a/packages/metamask/src/index.ts
+++ b/packages/metamask/src/index.ts
@@ -121,7 +121,9 @@ export class MetaMask extends Connector {
    */
   public async activate(desiredChainIdOrChainParameters?: number | AddEthereumChainParameter): Promise<void> {
     let cancelActivation: () => void
-    if (!this.provider?.isConnected?.()) cancelActivation = this.actions.startActivation()
+    if (typeof this.provider?.isConnected === 'function' && !this.provider.isConnected()) {
+      cancelActivation = this.actions.startActivation()
+    }
 
     return this.isomorphicInitialize()
       .then(async () => {


### PR DESCRIPTION
A [EIP-1193 spec](https://eips.ethereum.org/EIPS/eip-1193) does not describe an "isConnected()" method, so if this method is not found on the provider, the dapp should not assume it is not connected.

Instead, we can only perform the check if the method is found.

This fixed a bug when the UI goes into a infinite cycle of switching
the network back and forth.