### PR TITLE
Ignore the MetaMask error with code 1013

### DIFF
--- a/packages/metamask/src/index.ts
+++ b/packages/metamask/src/index.ts
@@ -64,9 +64,9 @@ export class MetaMask extends Connector {
 
         this.provider.on('disconnect', (error: ProviderRpcError): void => {
           // 1013 indicates that MetaMask is attempting to reestablish the connection
-          // https://github.com/MetaMask/providers/releases
+          // https://github.com/MetaMask/providers/releases/tag/v8.0.0
           if (error.code === 1013) {
-            console.error('Ignore the error (1013): "MetaMask: Disconnected from chain. Attempting to connect.:"', error);
+            console.debug('MetaMask logged connection error 1013: "Try again later"');
             return;
           }
           this.actions.resetState()

--- a/packages/metamask/src/index.ts
+++ b/packages/metamask/src/index.ts
@@ -66,8 +66,8 @@ export class MetaMask extends Connector {
           // 1013 indicates that MetaMask is attempting to reestablish the connection
           // https://github.com/MetaMask/providers/releases/tag/v8.0.0
           if (error.code === 1013) {
-            console.debug('MetaMask logged connection error 1013: "Try again later"');
-            return;
+            console.debug('MetaMask logged connection error 1013: "Try again later"')
+            return
           }
           this.actions.resetState()
           this.onError?.(error)

--- a/packages/metamask/src/index.ts
+++ b/packages/metamask/src/index.ts
@@ -63,6 +63,12 @@ export class MetaMask extends Connector {
         })
 
         this.provider.on('disconnect', (error: ProviderRpcError): void => {
+          // 1013 indicates that MetaMask is attempting to reestablish the connection
+          // https://github.com/MetaMask/providers/releases
+          if (error.code === 1013) {
+            console.log('Ignore the error (1013): "MetaMask: Disconnected from chain. Attempting to connect.:"', error);
+            return;
+          }
           this.actions.resetState()
           this.onError?.(error)
         })

--- a/packages/metamask/src/index.ts
+++ b/packages/metamask/src/index.ts
@@ -66,7 +66,7 @@ export class MetaMask extends Connector {
           // 1013 indicates that MetaMask is attempting to reestablish the connection
           // https://github.com/MetaMask/providers/releases
           if (error.code === 1013) {
-            console.log('Ignore the error (1013): "MetaMask: Disconnected from chain. Attempting to connect.:"', error);
+            console.error('Ignore the error (1013): "MetaMask: Disconnected from chain. Attempting to connect.:"', error);
             return;
           }
           this.actions.resetState()


### PR DESCRIPTION
The error 1013 shouldn't lead to the wallet disconnection, because it's just an attempting to reestablish the connection.

It blocks https://github.com/cowprotocol/cowswap/pull/924