### PR TITLE
Fix chain switch on android (metamask)

### DIFF
--- a/packages/metamask/src/index.ts
+++ b/packages/metamask/src/index.ts
@@ -150,7 +150,14 @@ export class MetaMask extends Connector {
             params: [{ chainId: desiredChainIdHex }],
           })
             .catch((error: ProviderRpcError) => {
-              if (error.code === 4902 && typeof desiredChainIdOrChainParameters !== 'number') {
+              if (
+                  (
+                    error.code === 4902 || 
+                    (error as any)?.data?.originalError?.code === 4902 ||
+                    error.message.startsWith('Unrecognized chain ID')
+                  ) && 
+                  typeof desiredChainIdOrChainParameters !== 'number'
+                ) {
                 // if we're here, we can try to add a new network
                 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                 return this.provider!.request({


### PR DESCRIPTION
MetaMask throws a different error on android when switching chain
![image](https://user-images.githubusercontent.com/53352199/196444460-854bd671-8964-48b6-9c57-5e2017b82f17.png)
