### PR TITLE
fix: use up-to-date chainId/accounts when querying EIP1193-derived wallets

### DIFF
--- a/packages/coinbase-wallet/src/index.spec.ts
+++ b/packages/coinbase-wallet/src/index.spec.ts
@@ -35,7 +35,7 @@ describe('Coinbase Wallet', () => {
 
       const mockProvider = connector.provider as unknown as MockEIP1193Provider
       mockProvider.eth_chainId.mockResolvedValue('0x0' as never)
-      mockProvider.eth_accounts.mockResolvedValue([] as never)
+      mockProvider.eth_requestAccounts.mockResolvedValue([] as never)
       mockProvider.chainId = chainId
       mockProvider.accounts = accounts
     })

--- a/packages/coinbase-wallet/src/index.spec.ts
+++ b/packages/coinbase-wallet/src/index.spec.ts
@@ -19,7 +19,6 @@ const accounts: string[] = []
 describe('Coinbase Wallet', () => {
   let store: Web3ReactStore
   let connector: CoinbaseWallet
-  let mockConnector: MockEIP1193Provider
 
   describe('connectEagerly = true', () => {
     beforeEach(async () => {
@@ -34,9 +33,11 @@ describe('Coinbase Wallet', () => {
       })
       await connector.connectEagerly().catch(() => {})
 
-      mockConnector = connector.provider as unknown as MockEIP1193Provider
-      mockConnector.chainId = chainId
-      mockConnector.accounts = accounts
+      const mockProvider = connector.provider as unknown as MockEIP1193Provider
+      mockProvider.eth_chainId.mockResolvedValue('0x0' as never)
+      mockProvider.eth_accounts.mockResolvedValue([] as never)
+      mockProvider.chainId = chainId
+      mockProvider.accounts = accounts
     })
 
     test('#activate', async () => {

--- a/packages/coinbase-wallet/src/index.spec.ts
+++ b/packages/coinbase-wallet/src/index.spec.ts
@@ -1,7 +1,7 @@
 import { createWeb3ReactStoreAndActions } from '@web3-react/store'
 import type { Actions, Web3ReactStore } from '@web3-react/types'
 import { CoinbaseWallet } from '.'
-import { MockEIP1193Provider } from '../../eip1193/src/index.spec'
+import { MockEIP1193Provider } from '../../eip1193/src/mock'
 
 jest.mock(
   '@coinbase/wallet-sdk',

--- a/packages/coinbase-wallet/src/index.ts
+++ b/packages/coinbase-wallet/src/index.ts
@@ -90,8 +90,8 @@ export class CoinbaseWallet extends Connector {
       // Wallets may resolve eth_chainId and hang on eth_accounts pending user interaction, which may include changing
       // chains; they should be requested serially, with accounts first, so that the chainId can settle.
       const accounts = await this.provider.request<string[]>({ method: 'eth_accounts' }) 
-      const chainId = await this.provider.request<string>({ method: 'eth_chainId' }) 
       if (!accounts.length) throw new Error('No accounts returned')
+      const chainId = await this.provider.request<string>({ method: 'eth_chainId' }) 
       this.actions.update({ chainId: parseChainId(chainId), accounts })
     } catch (error) {
       cancelActivation()

--- a/packages/coinbase-wallet/src/index.ts
+++ b/packages/coinbase-wallet/src/index.ts
@@ -87,15 +87,12 @@ export class CoinbaseWallet extends Connector {
 
       if (!this.provider || !this.connected) throw new Error('No existing connection')
 
-      return Promise.all([
-        this.provider.request<string[]>({ method: 'eth_accounts' }),
-        this.provider.request<string>({ method: 'eth_chainId' }),
-      ]).then(([accounts]) => {
-        if (!this.provider) throw new Error('No provider')
-        const { chainId } = this.provider // use the synchronous getter in case there have been updates
-        if (!accounts.length) throw new Error('No accounts returned')
-        this.actions.update({ chainId: parseChainId(chainId), accounts })
-      })
+      // Wallets may resolve eth_chainId and hang on eth_accounts pending user interaction, which may include changing
+      // chains; they should be requested serially, with accounts first, so that the chainId can settle.
+      const accounts = await this.provider.request<string[]>({ method: 'eth_accounts' }) 
+      const chainId = await this.provider.request<string>({ method: 'eth_chainId' }) 
+      if (!accounts.length) throw new Error('No accounts returned')
+      this.actions.update({ chainId: parseChainId(chainId), accounts })
     } catch (error) {
       cancelActivation()
       throw error
@@ -144,37 +141,34 @@ export class CoinbaseWallet extends Connector {
       await this.isomorphicInitialize()
       if (!this.provider) throw new Error('No provider')
 
-      return Promise.all([
-        this.provider.request<string[]>({ method: 'eth_requestAccounts' }),
-        this.provider.request<string>({ method: 'eth_chainId' }),
-      ]).then(([accounts]) => {
-        if (!this.provider) throw new Error('No provider')
-        const { chainId } = this.provider // use the synchronous getter in case there have been updates
-        const receivedChainId = parseChainId(chainId)
+      // Wallets may resolve eth_chainId and hang on eth_accounts pending user interaction, which may include changing
+      // chains; they should be requested serially, with accounts first, so that the chainId can settle.
+      const accounts = await this.provider.request<string[]>({ method: 'eth_requestAccounts' })
+      const chainId = await this.provider.request<string>({ method: 'eth_chainId' })
+      const receivedChainId = parseChainId(chainId)
 
-        if (!desiredChainId || desiredChainId === receivedChainId)
-          return this.actions.update({ chainId: receivedChainId, accounts })
+      if (!desiredChainId || desiredChainId === receivedChainId)
+        return this.actions.update({ chainId: receivedChainId, accounts })
 
-        // if we're here, we can try to switch networks
-        const desiredChainIdHex = `0x${desiredChainId.toString(16)}`
-        return this.provider
-          ?.request<void>({
-            method: 'wallet_switchEthereumChain',
-            params: [{ chainId: desiredChainIdHex }],
-          })
-          .catch(async (error: ProviderRpcError) => {
-            if (error.code === 4902 && typeof desiredChainIdOrChainParameters !== 'number') {
-              if (!this.provider) throw new Error('No provider')
-              // if we're here, we can try to add a new network
-              return this.provider.request<void>({
-                method: 'wallet_addEthereumChain',
-                params: [{ ...desiredChainIdOrChainParameters, chainId: desiredChainIdHex }],
-              })
-            }
+      // if we're here, we can try to switch networks
+      const desiredChainIdHex = `0x${desiredChainId.toString(16)}`
+      return this.provider
+        ?.request<void>({
+          method: 'wallet_switchEthereumChain',
+          params: [{ chainId: desiredChainIdHex }],
+        })
+        .catch(async (error: ProviderRpcError) => {
+          if (error.code === 4902 && typeof desiredChainIdOrChainParameters !== 'number') {
+            if (!this.provider) throw new Error('No provider')
+            // if we're here, we can try to add a new network
+            return this.provider.request<void>({
+              method: 'wallet_addEthereumChain',
+              params: [{ ...desiredChainIdOrChainParameters, chainId: desiredChainIdHex }],
+            })
+          }
 
-            throw error
-          })
-      })
+          throw error
+        })
     } catch (error) {
       cancelActivation()
       throw error

--- a/packages/eip1193/src/index.spec.ts
+++ b/packages/eip1193/src/index.spec.ts
@@ -4,53 +4,13 @@ import { createWeb3ReactStoreAndActions } from '@web3-react/store'
 import type { Actions, ProviderRpcError, RequestArguments, Web3ReactStore } from '@web3-react/types'
 import { EventEmitter } from 'node:events'
 import { EIP1193 } from '.'
+import { MockEIP1193Provider } from './mock'
 
 class MockProviderRpcError extends Error {
   public code: number
   constructor() {
     super('Mock Provider RPC Error')
     this.code = 4200
-  }
-}
-
-export class MockEIP1193Provider extends EventEmitter {
-  public chainId?: string
-  public accounts?: string[]
-
-  public eth_chainId = jest.fn((chainId?: string) => chainId)
-  public eth_accounts = jest.fn((accounts?: string[]) => accounts)
-  public eth_requestAccounts = jest.fn((accounts?: string[]) => accounts)
-
-  public request(x: RequestArguments): Promise<unknown> {
-    // make sure to throw if we're "not connected"
-    if (!this.chainId) return Promise.reject(new Error())
-
-    switch (x.method) {
-      case 'eth_chainId':
-        return Promise.resolve(this.eth_chainId(this.chainId))
-      case 'eth_accounts':
-        return Promise.resolve(this.eth_accounts(this.accounts))
-      case 'eth_requestAccounts':
-        return Promise.resolve(this.eth_requestAccounts(this.accounts))
-      default:
-        throw new Error()
-    }
-  }
-
-  public emitConnect(chainId: string) {
-    this.emit('connect', { chainId })
-  }
-
-  public emitDisconnect(error: ProviderRpcError) {
-    this.emit('disconnect', error)
-  }
-
-  public emitChainChanged(chainId: string) {
-    this.emit('chainChanged', chainId)
-  }
-
-  public emitAccountsChanged(accounts: string[]) {
-    this.emit('accountsChanged', accounts)
   }
 }
 

--- a/packages/eip1193/src/index.spec.ts
+++ b/packages/eip1193/src/index.spec.ts
@@ -103,23 +103,8 @@ describe('EIP1193', () => {
         expect(mockProvider.eth_chainId.mock.calls.length).toBe(1)
         expect(mockProvider.eth_accounts.mock.calls.length).toBe(1)
         expect(mockProvider.eth_requestAccounts.mock.calls.length).toBe(0)
-      })
-    
-      test('succeeds with updating state', async () => {
-        mockProvider.chainId = chainId
-        mockProvider.accounts = accounts
-
-        connector = new EIP1193({ actions, provider: mockProvider })
-        const connect = connector.connectEagerly()
-        mockProvider.emitChainChanged('0x2')
-        mockProvider.emitAccountsChanged(['0x0000000000000000000000000000000000000000'])
-        await connect
-
-        expect(store.getState()).toEqual({
-          chainId: 2,
-          accounts: ['0x0000000000000000000000000000000000000000'],
-          activating: false,
-        })
+        expect(mockProvider.eth_chainId.mock.invocationCallOrder[0])
+          .toBeGreaterThan(mockProvider.eth_accounts.mock.invocationCallOrder[0])
       })
     })
 
@@ -147,22 +132,8 @@ describe('EIP1193', () => {
           expect(mockProvider.eth_chainId.mock.calls.length).toBe(1)
           expect(mockProvider.eth_accounts.mock.calls.length).toBe(0)
           expect(mockProvider.eth_requestAccounts.mock.calls.length).toBe(1)
-        })
-
-        test('with updating state', async () => {
-          mockProvider.chainId = chainId
-          mockProvider.accounts = accounts
-
-          const connect = connector.activate()
-          mockProvider.emitChainChanged('0x2')
-          mockProvider.emitAccountsChanged(['0x0000000000000000000000000000000000000000'])
-          await connect
-
-          expect(store.getState()).toEqual({
-            chainId: 2,
-            accounts: ['0x0000000000000000000000000000000000000000'],
-            activating: false,
-          })
+          expect(mockProvider.eth_chainId.mock.invocationCallOrder[0])
+            .toBeGreaterThan(mockProvider.eth_requestAccounts.mock.invocationCallOrder[0])
         })
 
         test(`chainId = ${chainId}`, async () => {

--- a/packages/eip1193/src/index.ts
+++ b/packages/eip1193/src/index.ts
@@ -55,7 +55,7 @@ export class EIP1193 extends Connector {
     this.chainId = this.accounts = undefined
     return Promise.all([
       this.provider.request({ method: 'eth_chainId' }) as Promise<string>,
-      (eager ? this.provider.request({ method: 'eth_requestAccounts' }) : this.provider
+      (eager ? this.provider.request({ method: 'eth_accounts' }) : this.provider
         .request({ method: 'eth_requestAccounts' })
         .catch(() => this.provider.request({ method: 'eth_accounts' }))) as Promise<string[]>,
     ])

--- a/packages/eip1193/src/mock.ts
+++ b/packages/eip1193/src/mock.ts
@@ -1,0 +1,43 @@
+import type { ProviderRpcError, RequestArguments } from '@web3-react/types'
+import { EventEmitter } from 'node:events'
+
+export class MockEIP1193Provider extends EventEmitter {
+  public chainId?: string
+  public accounts?: string[]
+
+  public eth_chainId = jest.fn((chainId?: string) => chainId)
+  public eth_accounts = jest.fn((accounts?: string[]) => accounts)
+  public eth_requestAccounts = jest.fn((accounts?: string[]) => accounts)
+
+  public request(x: RequestArguments): Promise<unknown> {
+    // make sure to throw if we're "not connected"
+    if (!this.chainId) return Promise.reject(new Error())
+
+    switch (x.method) {
+      case 'eth_chainId':
+        return Promise.resolve(this.eth_chainId(this.chainId))
+      case 'eth_accounts':
+        return Promise.resolve(this.eth_accounts(this.accounts))
+      case 'eth_requestAccounts':
+        return Promise.resolve(this.eth_requestAccounts(this.accounts))
+      default:
+        throw new Error()
+    }
+  }
+
+  public emitConnect(chainId: string) {
+    this.emit('connect', { chainId })
+  }
+
+  public emitDisconnect(error: ProviderRpcError) {
+    this.emit('disconnect', error)
+  }
+
+  public emitChainChanged(chainId: string) {
+    this.emit('chainChanged', chainId)
+  }
+
+  public emitAccountsChanged(accounts: string[]) {
+    this.emit('accountsChanged', accounts)
+  }
+}

--- a/packages/metamask/src/index.spec.ts
+++ b/packages/metamask/src/index.spec.ts
@@ -28,14 +28,14 @@ describe('MetaMask', () => {
 
   test('#activate', async () => {
     mockProvider.eth_chainId.mockResolvedValue('0x0' as never)
-    mockProvider.eth_accounts.mockResolvedValue([] as never)
+    mockProvider.eth_requestAccounts.mockResolvedValue([] as never)
     mockProvider.chainId = chainId
     mockProvider.accounts = accounts
 
     await connector.activate()
 
     expect(mockProvider.eth_chainId).toHaveBeenCalled()
-    expect(mockProvider.eth_accounts).toHaveBeenCalled()
+    expect(mockProvider.eth_requestAccounts).toHaveBeenCalled()
     expect(store.getState()).toEqual({
       chainId: Number.parseInt(chainId, 16),
       accounts,

--- a/packages/metamask/src/index.spec.ts
+++ b/packages/metamask/src/index.spec.ts
@@ -4,7 +4,7 @@ import { MetaMask } from '.'
 import { MockEIP1193Provider } from '../../eip1193/src/mock'
 
 const chainId = '0x1'
-const accounts: string[] = []
+const accounts: string[] = ['0x0000000000000000000000000000000000000000']
 
 describe('MetaMask', () => {
   let mockProvider: MockEIP1193Provider
@@ -26,16 +26,37 @@ describe('MetaMask', () => {
     connector = new MetaMask({ actions })
   })
 
+  test('#connectEagerly', async () => {
+    mockProvider.chainId = chainId
+    mockProvider.accounts = accounts
+
+    await connector.connectEagerly()
+
+    expect(mockProvider.eth_requestAccounts).not.toHaveBeenCalled()
+    expect(mockProvider.eth_accounts).toHaveBeenCalled()
+    expect(mockProvider.eth_chainId).toHaveBeenCalled()
+    expect(mockProvider.eth_chainId.mock.invocationCallOrder[0])
+      .toBeGreaterThan(mockProvider.eth_accounts.mock.invocationCallOrder[0])
+
+    expect(store.getState()).toEqual({
+      chainId: Number.parseInt(chainId, 16),
+      accounts,
+      activating: false,
+    })
+  })
+
   test('#activate', async () => {
-    mockProvider.eth_chainId.mockResolvedValue('0x0' as never)
-    mockProvider.eth_requestAccounts.mockResolvedValue([] as never)
     mockProvider.chainId = chainId
     mockProvider.accounts = accounts
 
     await connector.activate()
 
-    expect(mockProvider.eth_chainId).toHaveBeenCalled()
     expect(mockProvider.eth_requestAccounts).toHaveBeenCalled()
+    expect(mockProvider.eth_accounts).not.toHaveBeenCalled()
+    expect(mockProvider.eth_chainId).toHaveBeenCalled()
+    expect(mockProvider.eth_chainId.mock.invocationCallOrder[0])
+      .toBeGreaterThan(mockProvider.eth_requestAccounts.mock.invocationCallOrder[0])
+
     expect(store.getState()).toEqual({
       chainId: Number.parseInt(chainId, 16),
       accounts,

--- a/packages/metamask/src/index.spec.ts
+++ b/packages/metamask/src/index.spec.ts
@@ -1,7 +1,7 @@
 import { createWeb3ReactStoreAndActions } from '@web3-react/store'
 import type { Actions, Web3ReactStore } from '@web3-react/types'
 import { MetaMask } from '.'
-import { MockEIP1193Provider } from '../../eip1193/src/index.spec'
+import { MockEIP1193Provider } from '../../eip1193/src/mock'
 
 const chainId = '0x1'
 const accounts: string[] = []

--- a/packages/metamask/src/index.spec.ts
+++ b/packages/metamask/src/index.spec.ts
@@ -27,11 +27,15 @@ describe('MetaMask', () => {
   })
 
   test('#activate', async () => {
+    mockProvider.eth_chainId.mockResolvedValue('0x0' as never)
+    mockProvider.eth_accounts.mockResolvedValue([] as never)
     mockProvider.chainId = chainId
     mockProvider.accounts = accounts
 
     await connector.activate()
 
+    expect(mockProvider.eth_chainId).toHaveBeenCalled()
+    expect(mockProvider.eth_accounts).toHaveBeenCalled()
     expect(store.getState()).toEqual({
       chainId: Number.parseInt(chainId, 16),
       accounts,

--- a/packages/metamask/src/index.ts
+++ b/packages/metamask/src/index.ts
@@ -105,12 +105,9 @@ export class MetaMask extends Connector {
       // Wallets may resolve eth_chainId and hang on eth_accounts pending user interaction, which may include changing
       // chains; they should be requested serially, with accounts first, so that the chainId can settle.
       const accounts = await this.provider.request({ method: 'eth_accounts' }) as string[]
+      if (!accounts.length) throw new Error('No accounts returned')
       const chainId = await this.provider.request({ method: 'eth_chainId' }) as string
-      if (accounts.length) {
-        this.actions.update({ chainId: parseChainId(chainId), accounts })
-      } else {
-        throw new Error('No accounts returned')
-      }
+      this.actions.update({ chainId: parseChainId(chainId), accounts })
     } catch (error) {
         console.debug('Could not connect eagerly', error)
         // we should be able to use `cancelActivation` here, but on mobile, metamask emits a 'connect'

--- a/packages/metamask/src/index.ts
+++ b/packages/metamask/src/index.ts
@@ -98,29 +98,26 @@ export class MetaMask extends Connector {
   public async connectEagerly(): Promise<void> {
     const cancelActivation = this.actions.startActivation()
 
-    await this.isomorphicInitialize()
-    if (!this.provider) return cancelActivation()
+    try {
+      await this.isomorphicInitialize()
+      if (!this.provider) return cancelActivation()
 
-    return Promise.all([
-      this.provider.request({ method: 'eth_accounts' }) as Promise<string[]>,
-      this.provider.request({ method: 'eth_chainId' }) as Promise<string>,
-    ])
-      .then(([accounts]) => {
-        if (!this.provider) throw new Error('No provider')
-        const { chainId } = this.provider // use the synchronous getter in case there have been updates
-        if (accounts.length) {
-          this.actions.update({ chainId: parseChainId(chainId), accounts })
-        } else {
-          throw new Error('No accounts returned')
-        }
-      })
-      .catch((error) => {
+      // Wallets may resolve eth_chainId and hang on eth_accounts pending user interaction, which may include changing
+      // chains; they should be requested serially, with accounts first, so that the chainId can settle.
+      const accounts = await this.provider.request({ method: 'eth_accounts' }) as string[]
+      const chainId = await this.provider.request({ method: 'eth_chainId' }) as string
+      if (accounts.length) {
+        this.actions.update({ chainId: parseChainId(chainId), accounts })
+      } else {
+        throw new Error('No accounts returned')
+      }
+    } catch (error) {
         console.debug('Could not connect eagerly', error)
         // we should be able to use `cancelActivation` here, but on mobile, metamask emits a 'connect'
         // event, meaning that chainId is updated, and cancelActivation doesn't work because an intermediary
         // update has occurred, so we reset state instead
         this.actions.resetState()
-      })
+    }
   }
 
   /**
@@ -140,43 +137,40 @@ export class MetaMask extends Connector {
       .then(async () => {
         if (!this.provider) throw new NoMetaMaskError()
 
-        return Promise.all([
-          this.provider.request({ method: 'eth_requestAccounts' }) as Promise<string[]>,
-          this.provider.request({ method: 'eth_chainId' }) as Promise<string>,
-        ]).then(([accounts]) => {
-          if (!this.provider) throw new Error('No provider')
-          const { chainId } = this.provider // use the synchronous getter in case there have been updates
-          const receivedChainId = parseChainId(chainId)
-          const desiredChainId =
-            typeof desiredChainIdOrChainParameters === 'number'
-              ? desiredChainIdOrChainParameters
-              : desiredChainIdOrChainParameters?.chainId
+        // Wallets may resolve eth_chainId and hang on eth_accounts pending user interaction, which may include changing
+        // chains; they should be requested serially, with accounts first, so that the chainId can settle.
+        const accounts = await this.provider.request({ method: 'eth_requestAccounts' }) as string[]
+        const chainId = await this.provider.request({ method: 'eth_chainId' }) as string
+        const receivedChainId = parseChainId(chainId)
+        const desiredChainId =
+          typeof desiredChainIdOrChainParameters === 'number'
+            ? desiredChainIdOrChainParameters
+            : desiredChainIdOrChainParameters?.chainId
 
-          // if there's no desired chain, or it's equal to the received, update
-          if (!desiredChainId || receivedChainId === desiredChainId)
-            return this.actions.update({ chainId: receivedChainId, accounts })
+        // if there's no desired chain, or it's equal to the received, update
+        if (!desiredChainId || receivedChainId === desiredChainId)
+          return this.actions.update({ chainId: receivedChainId, accounts })
 
-          const desiredChainIdHex = `0x${desiredChainId.toString(16)}`
+        const desiredChainIdHex = `0x${desiredChainId.toString(16)}`
 
-          // if we're here, we can try to switch networks
-          return this.provider.request({
-            method: 'wallet_switchEthereumChain',
-            params: [{ chainId: desiredChainIdHex }],
-          })
-            .catch((error: ProviderRpcError) => {
-              if (error.code === 4902 && typeof desiredChainIdOrChainParameters !== 'number') {
-                if (!this.provider) throw new Error('No provider')
-                // if we're here, we can try to add a new network
-                return this.provider.request({
-                  method: 'wallet_addEthereumChain',
-                  params: [{ ...desiredChainIdOrChainParameters, chainId: desiredChainIdHex }],
-                })
-              }
-
-              throw error
-            })
-            .then(() => this.activate(desiredChainId))
+        // if we're here, we can try to switch networks
+        return this.provider.request({
+          method: 'wallet_switchEthereumChain',
+          params: [{ chainId: desiredChainIdHex }],
         })
+          .catch((error: ProviderRpcError) => {
+            if (error.code === 4902 && typeof desiredChainIdOrChainParameters !== 'number') {
+              if (!this.provider) throw new Error('No provider')
+              // if we're here, we can try to add a new network
+              return this.provider.request({
+                method: 'wallet_addEthereumChain',
+                params: [{ ...desiredChainIdOrChainParameters, chainId: desiredChainIdHex }],
+              })
+            }
+
+            throw error
+          })
+          .then(() => this.activate(desiredChainId))
       })
       .catch((error) => {
         cancelActivation?.()

--- a/packages/walletconnect/src/index.spec.ts
+++ b/packages/walletconnect/src/index.spec.ts
@@ -2,7 +2,7 @@ import { createWeb3ReactStoreAndActions } from '@web3-react/store'
 import type { Actions, RequestArguments, Web3ReactStore } from '@web3-react/types'
 import EventEmitter from 'node:events'
 import { WalletConnect } from '.'
-import { MockEIP1193Provider } from '../../eip1193/src/index.spec'
+import { MockEIP1193Provider } from '../../eip1193/src/mock'
 
 // necessary because walletconnect returns chainId as a number
 class MockMockWalletConnectProvider extends MockEIP1193Provider {

--- a/packages/walletconnect/src/index.spec.ts
+++ b/packages/walletconnect/src/index.spec.ts
@@ -29,7 +29,7 @@ const accounts: string[] = []
 describe('WalletConnect', () => {
   let store: Web3ReactStore
   let connector: WalletConnect
-  let mockConnector: MockMockWalletConnectProvider
+  let mockProvider: MockMockWalletConnectProvider
 
   describe('works', () => {
     beforeEach(async () => {
@@ -40,11 +40,14 @@ describe('WalletConnect', () => {
 
     test('#activate', async () => {
       await connector.connectEagerly().catch(() => {})
-      mockConnector = connector.provider as unknown as MockMockWalletConnectProvider
-      mockConnector.chainId = chainId
-      mockConnector.accounts = accounts
+      mockProvider = connector.provider as unknown as MockMockWalletConnectProvider
+      mockProvider.eth_chainId.mockResolvedValue('0x0' as never)
+      mockProvider.eth_requestAccounts.mockResolvedValue([] as never)
+      mockProvider.chainId = chainId
+      mockProvider.accounts = accounts
       await connector.activate()
 
+      expect(mockProvider.eth_requestAccounts).toHaveBeenCalled()
       expect(store.getState()).toEqual({
         chainId: Number.parseInt(chainId, 16),
         accounts,

--- a/packages/walletconnect/src/index.spec.ts
+++ b/packages/walletconnect/src/index.spec.ts
@@ -40,14 +40,19 @@ describe('WalletConnect', () => {
 
     test('#activate', async () => {
       await connector.connectEagerly().catch(() => {})
+
       mockProvider = connector.provider as unknown as MockMockWalletConnectProvider
-      mockProvider.eth_chainId.mockResolvedValue('0x0' as never)
-      mockProvider.eth_requestAccounts.mockResolvedValue([] as never)
       mockProvider.chainId = chainId
       mockProvider.accounts = accounts
+
       await connector.activate()
 
       expect(mockProvider.eth_requestAccounts).toHaveBeenCalled()
+      expect(mockProvider.eth_accounts).not.toHaveBeenCalled()
+      expect(mockProvider.eth_chainId_number).toHaveBeenCalled()
+      expect(mockProvider.eth_chainId_number.mock.invocationCallOrder[0])
+        .toBeGreaterThan(mockProvider.eth_requestAccounts.mock.invocationCallOrder[0])
+
       expect(store.getState()).toEqual({
         chainId: Number.parseInt(chainId, 16),
         accounts,

--- a/packages/walletconnect/src/index.ts
+++ b/packages/walletconnect/src/index.ts
@@ -128,8 +128,8 @@ export class WalletConnect extends Connector {
       // Wallets may resolve eth_chainId and hang on eth_accounts pending user interaction, which may include changing
       // chains; they should be requested serially, with accounts first, so that the chainId can settle.
       const accounts = await this.provider.request<string[]>({ method: 'eth_accounts' })
-      const chainId = await this.provider.request<string>({ method: 'eth_chainId' })
       if (!accounts.length) throw new Error('No accounts returned')
+      const chainId = await this.provider.request<string>({ method: 'eth_chainId' })
 
       this.actions.update({ chainId: parseChainId(chainId), accounts })
     } catch (error) {


### PR DESCRIPTION
Serially requests `accounts` and then `chainId`, so that if a user changes chains whilst connecting, the new chain (after connection / `accounts`) will be used. Practically, this prevents web3-react from using incorrect initial state when connecting to certain wallets, in certain cases where the user selects a non-active chain. This is resolved by waiting for `accounts` to settle before requesting `chainId`.

---

For `chainId` and `accounts`, the values were fetched using a `Promise.all`. In some wallets, `chainId` resolves immediately, and then the user is prompted to change chains. In these cases, `chainId` will be outdated by the time `accounts` resolves:
1. `eth_chainId` resolves to "stale" chain
2. user is prompted to connect with a chain selector
3. user selects a different "active" chain
4. `chainChanged` is emitted
5. `eth_accounts` resolves, resolving the `Promise.all` with an out-of-date `chainId`

NB: WalletConnect did not exhibit this bug, but I updated it to keep it in sync with other connectors' idioms. It likely already had this "fix" in it, based on existing comments.