### PR TITLE
chore: remove unnecessary `esModuleInterop`

### DIFF
--- a/packages/walletconnect/tsconfig.json
+++ b/packages/walletconnect/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.json",
   "include": ["./src"],
   "compilerOptions": {
-    "outDir": "./dist",
-    "esModuleInterop": true
+    "outDir": "./dist"
   }
 }


### PR DESCRIPTION
I said in the last PR that it was necessary, but I realised that lack of this flag didn't trigger TypeScript issues anymore. The reason is actually quite simple: while migrating to Yarn workspaces, Yarn must've accidentally installed `eventemitter3@5.x` release that is an ESModule. Upon checking the source code, I can confirm that 4.x branch (the one we use) is a regular node module. 