### PR TITLE
fix: temporarily pin zustand version to 4.3.3

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@web3-react/store": "^8.1.0-beta.0",
     "@web3-react/types": "^8.1.0-beta.0",
-    "zustand": "^4.0.0"
+    "zustand": "4.3.4"
   },
   "peerDependencies": {
     "react": ">=16.8"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@web3-react/store": "^8.1.0-beta.0",
     "@web3-react/types": "^8.1.0-beta.0",
-    "zustand": "4.3.4"
+    "zustand": "4.3.3"
   },
   "peerDependencies": {
     "react": ">=16.8"

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -25,6 +25,6 @@
   "dependencies": {
     "@ethersproject/address": "^5",
     "@web3-react/types": "^8.1.0-beta.0",
-    "zustand": "4.3.4"
+    "zustand": "4.3.3"
   }
 }

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -25,6 +25,6 @@
   "dependencies": {
     "@ethersproject/address": "^5",
     "@web3-react/types": "^8.1.0-beta.0",
-    "zustand": "^4.0.0"
+    "zustand": "4.3.4"
   }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -23,6 +23,6 @@
     "start": "tsc --watch"
   },
   "dependencies": {
-    "zustand": "4.3.4"
+    "zustand": "4.3.3"
   }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -23,6 +23,6 @@
     "start": "tsc --watch"
   },
   "dependencies": {
-    "zustand": "^4.0.0"
+    "zustand": "4.3.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9704,9 +9704,9 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-zustand@4.3.4:
-  version "4.3.4"
-  resolved "https://registry.yarnpkg.com/zustand/-/zustand-4.3.4.tgz#55a1345656348218a690e437ee894dd042ac2440"
-  integrity sha512-QSV8MF80I4yM9UCcBhIBr5OcQkiTbZdxDofg5R5vyX49QsEia7sK1iwOhFyH/0hyNVg+h+OzARM76G8MgMno0g==
+zustand@4.3.3:
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-4.3.3.tgz#c9113499074dde2d6d99c1b5f591e9329572c224"
+  integrity sha512-x2jXq8S0kfLGNwGh87nhRfEc2eZy37tSatpSoSIN+O6HIaBhgQHSONV/F9VNrNcBcKQu/E80K1DeHDYQC/zCrQ==
   dependencies:
     use-sync-external-store "1.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9704,9 +9704,9 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-zustand@^4.0.0:
-  version "4.3.3"
-  resolved "https://registry.yarnpkg.com/zustand/-/zustand-4.3.3.tgz#c9113499074dde2d6d99c1b5f591e9329572c224"
-  integrity sha512-x2jXq8S0kfLGNwGh87nhRfEc2eZy37tSatpSoSIN+O6HIaBhgQHSONV/F9VNrNcBcKQu/E80K1DeHDYQC/zCrQ==
+zustand@4.3.4:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-4.3.4.tgz#55a1345656348218a690e437ee894dd042ac2440"
+  integrity sha512-QSV8MF80I4yM9UCcBhIBr5OcQkiTbZdxDofg5R5vyX49QsEia7sK1iwOhFyH/0hyNVg+h+OzARM76G8MgMno0g==
   dependencies:
     use-sync-external-store "1.2.0"


### PR DESCRIPTION
Pinning down Zustand to 4.3.3 as 4.3.4 is causing a regression as can be seen by checking the CI build status for each of the commits in this PR.

Reported here: https://github.com/pmndrs/zustand/issues/1662