### PR TITLE
Catch MetaMask mobile app 4902 error code on chain switching

### DIFF
--- a/packages/metamask/src/index.ts
+++ b/packages/metamask/src/index.ts
@@ -158,7 +158,7 @@ export class MetaMask extends Connector {
             params: [{ chainId: desiredChainIdHex }],
           })
           .catch((error: ProviderRpcError) => {
-            if (error.code === 4902 && typeof desiredChainIdOrChainParameters !== 'number') {
+            if ((error.data?.originalError?.code === 4902 || error.code === 4902) && typeof desiredChainIdOrChainParameters !== 'number') {
               if (!this.provider) throw new Error('No provider')
               // if we're here, we can try to add a new network
               return this.provider.request({


### PR DESCRIPTION
Hi, I am trying to make @web3-react work in the MetaMask mobile app and I am running into the unrecognized chain id error. Capturing the error object shows that apparently there is slight difference in the data-path of the desktop and mobile plugins.

Please pull in this one-liner to enable the metamask package to add chains via web3-react activate().

Mobile app error code:
{
  "code":-32603,
  "message":"Unrecognized chain ID \"0x13881\". Try adding the chain using wallet_addEthereumChain first.",
  "data":{
    "originalError":{
      "code":4902
      // missing message property
    }
  }
}