### PR TITLE
fix: unpin `zustand` now that upstream issue is resolved

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@web3-react/store": "^8.1.1-beta.0",
     "@web3-react/types": "^8.1.1-beta.0",
-    "zustand": "^4.3.6"
+    "zustand": "^4.3.5"
   },
   "peerDependencies": {
     "react": ">=16.8"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@web3-react/store": "^8.1.1-beta.0",
     "@web3-react/types": "^8.1.1-beta.0",
-    "zustand": "4.3.3"
+    "zustand": "^4.3.6"
   },
   "peerDependencies": {
     "react": ">=16.8"

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -25,6 +25,6 @@
   "dependencies": {
     "@ethersproject/address": "^5",
     "@web3-react/types": "^8.1.1-beta.0",
-    "zustand": "4.3.3"
+    "zustand": "^4.3.6"
   }
 }

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -25,6 +25,6 @@
   "dependencies": {
     "@ethersproject/address": "^5",
     "@web3-react/types": "^8.1.1-beta.0",
-    "zustand": "^4.3.6"
+    "zustand": "^4.3.5"
   }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -23,6 +23,6 @@
     "start": "tsc --watch"
   },
   "dependencies": {
-    "zustand": "4.3.3"
+    "zustand": "^4.3.6"
   }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -23,6 +23,6 @@
     "start": "tsc --watch"
   },
   "dependencies": {
-    "zustand": "^4.3.6"
+    "zustand": "^4.3.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10072,9 +10072,9 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-zustand@4.3.3:
-  version "4.3.3"
-  resolved "https://registry.yarnpkg.com/zustand/-/zustand-4.3.3.tgz#c9113499074dde2d6d99c1b5f591e9329572c224"
-  integrity sha512-x2jXq8S0kfLGNwGh87nhRfEc2eZy37tSatpSoSIN+O6HIaBhgQHSONV/F9VNrNcBcKQu/E80K1DeHDYQC/zCrQ==
+zustand@^4.3.6:
+  version "4.3.6"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-4.3.6.tgz#ce7804eb75361af0461a2d0536b65461ec5de86f"
+  integrity sha512-6J5zDxjxLE+yukC2XZWf/IyWVKnXT9b9HUv09VJ/bwGCpKNcaTqp7Ws28Xr8jnbvnZcdRaidztAPsXFBIqufiw==
   dependencies:
     use-sync-external-store "1.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10072,7 +10072,7 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-zustand@^4.3.6:
+zustand@^4.3.5:
   version "4.3.6"
   resolved "https://registry.yarnpkg.com/zustand/-/zustand-4.3.6.tgz#ce7804eb75361af0461a2d0536b65461ec5de86f"
   integrity sha512-6J5zDxjxLE+yukC2XZWf/IyWVKnXT9b9HUv09VJ/bwGCpKNcaTqp7Ws28Xr8jnbvnZcdRaidztAPsXFBIqufiw==


### PR DESCRIPTION
We have run into a bug in Zustand 4.3.4 that just got fixed https://github.com/pmndrs/zustand/commit/0c153cac18f3b9b6371b03d1ce537f8d10915dca and released under `4.3.5`. 