### PR TITLE
fix: chain WalletConnect 2 `on` and `removeListener` methods 

### DIFF
--- a/packages/walletconnect-v2/src/index.ts
+++ b/packages/walletconnect-v2/src/index.ts
@@ -101,19 +101,11 @@ export class WalletConnect extends Connector {
         rpcMap: await rpcMap,
       }))
 
-      /**
-       * TODO(INFRA-137):
-       * WalletConnect `on` and `removeListener` methods do not return the provider instance,
-       * but underlying EventEmitter instead. This is why we have to return `provider` explicitly later
-       * rather than here.
-       */
-      provider
+      return provider
         .on('disconnect', this.disconnectListener)
         .on('chainChanged', this.chainChangedListener)
         .on('accountsChanged', this.accountsChangedListener)
         .on('display_uri', this.URIListener)
-
-      return provider
     }))
   }
 
@@ -166,15 +158,12 @@ export class WalletConnect extends Connector {
 
   /** {@inheritdoc Connector.deactivate} */
   public async deactivate(): Promise<void> {
-    await this.provider
+    this.provider
       ?.removeListener('disconnect', this.disconnectListener)
       .removeListener('chainChanged', this.chainChangedListener)
       .removeListener('accountsChanged', this.accountsChangedListener)
       .removeListener('display_uri', this.URIListener)
-    /**
-     * TODO(INFRA-137): chain `disconnect()` too once WalletConnect fixes `removeListener` to return Provider instead of EventEmitter
-     */
-    this.provider?.disconnect()
+      .disconnect()
     this.provider = undefined
     this.eagerConnection = undefined
     this.actions.resetState()


### PR DESCRIPTION
Fixes INFRA-137

Fixed upstream via https://github.com/WalletConnect/walletconnect-monorepo/commit/1c739200e3a9185b9130f3069be8e6871f258887

We have updated WalletConnect in another PR recently to fix another issue and that was shipped in the meantime.