### PR TITLE
feat: replace node:events with eventemitter3

### DIFF
--- a/packages/eip1193/package.json
+++ b/packages/eip1193/package.json
@@ -24,7 +24,8 @@
     "start": "tsc --watch"
   },
   "dependencies": {
-    "@web3-react/types": "^8.1.2-beta.0"
+    "@web3-react/types": "^8.1.2-beta.0",
+    "eventemitter3": "^4.0.7"
   },
   "devDependencies": {
     "@ethersproject/experimental": "^5.6.0",

--- a/packages/eip1193/src/index.spec.ts
+++ b/packages/eip1193/src/index.spec.ts
@@ -1,8 +1,7 @@
 import { Eip1193Bridge } from '@ethersproject/experimental'
 import { Web3Provider } from '@ethersproject/providers'
 import { createWeb3ReactStoreAndActions } from '@web3-react/store'
-import type { Actions, ProviderRpcError, RequestArguments, Web3ReactStore } from '@web3-react/types'
-import { EventEmitter } from 'node:events'
+import type { Actions, Web3ReactStore } from '@web3-react/types'
 import { EIP1193 } from '.'
 import { MockEIP1193Provider } from './mock'
 

--- a/packages/eip1193/src/mock.ts
+++ b/packages/eip1193/src/mock.ts
@@ -1,6 +1,5 @@
-import { EventEmitter } from 'node:events'
-
 import type { ProviderRpcError, RequestArguments } from '@web3-react/types'
+import { EventEmitter } from 'eventemitter3'
 
 export class MockEIP1193Provider extends EventEmitter {
   public chainId?: string

--- a/packages/walletconnect/src/index.spec.ts
+++ b/packages/walletconnect/src/index.spec.ts
@@ -1,6 +1,6 @@
 import { createWeb3ReactStoreAndActions } from '@web3-react/store'
 import type { Actions, RequestArguments, Web3ReactStore } from '@web3-react/types'
-import EventEmitter from 'node:events'
+import EventEmitter from 'eventemitter3'
 import { WalletConnect } from '.'
 import { MockEIP1193Provider } from '../../eip1193/src/mock'
 

--- a/packages/walletconnect/src/index.ts
+++ b/packages/walletconnect/src/index.ts
@@ -1,10 +1,8 @@
-import type { EventEmitter } from 'node:events'
-
 import type WalletConnectProvider from '@walletconnect/ethereum-provider'
 import type { IWCEthRpcConnectionOptions } from '@walletconnect/types'
 import type { Actions, ProviderRpcError } from '@web3-react/types'
 import { Connector } from '@web3-react/types'
-import EventEmitter3 from 'eventemitter3'
+import EventEmitter from 'eventemitter3'
 
 import { getBestUrl } from './utils'
 
@@ -47,7 +45,7 @@ export interface ActivateOptions {
 export class WalletConnect extends Connector {
   /** {@inheritdoc Connector.provider} */
   public provider?: MockWalletConnectProvider
-  public readonly events = new EventEmitter3()
+  public readonly events = new EventEmitter()
 
   private readonly options: Omit<WalletConnectOptions, 'rpc'>
   private readonly rpc: { [chainId: number]: string[] }


### PR DESCRIPTION
Aligns eip1193 with other providers that already use eventemitter3. Removes some unused imports in the test suite too.