### PR TITLE
feat: export and share MockEip1193 provider and use it throughout the test suite

### DIFF
--- a/packages/coinbase-wallet/src/index.spec.ts
+++ b/packages/coinbase-wallet/src/index.spec.ts
@@ -1,7 +1,7 @@
 import { createWeb3ReactStoreAndActions } from '@web3-react/store'
 import type { Actions, Web3ReactStore } from '@web3-react/types'
 import { CoinbaseWallet } from '.'
-import { MockEIP1193Provider } from '../../eip1193/src/mock'
+import { MockEIP1193Provider } from '@web3-react/core'
 
 jest.mock(
   '@coinbase/wallet-sdk',

--- a/packages/core/src/index.tsx
+++ b/packages/core/src/index.tsx
@@ -1,2 +1,3 @@
 export * from './hooks'
+export * from './mocks'
 export * from './provider'

--- a/packages/core/src/mocks.ts
+++ b/packages/core/src/mocks.ts
@@ -2,11 +2,11 @@ import { EventEmitter } from 'node:events'
 
 import type { ProviderRpcError, RequestArguments } from '@web3-react/types'
 
-export class MockEIP1193Provider extends EventEmitter {
-  public chainId?: string
+export class MockEIP1193Provider<T = string> extends EventEmitter {
+  public chainId?: T
   public accounts?: string[]
 
-  public eth_chainId = jest.fn((chainId?: string) => chainId)
+  public eth_chainId = jest.fn((chainId?: T) => chainId)
   public eth_accounts = jest.fn((accounts?: string[]) => accounts)
   public eth_requestAccounts = jest.fn((accounts?: string[]) => accounts)
 
@@ -22,7 +22,7 @@ export class MockEIP1193Provider extends EventEmitter {
       case 'eth_requestAccounts':
         return Promise.resolve(this.eth_requestAccounts(this.accounts))
       default:
-        throw new Error()
+        throw new Error(`Method not supported: ${JSON.stringify(x)}`)
     }
   }
 

--- a/packages/core/src/mocks.ts
+++ b/packages/core/src/mocks.ts
@@ -21,7 +21,7 @@ export class MockEIP1193Provider<T = string> extends EventEmitter {
       case 'eth_requestAccounts':
         return Promise.resolve(this.eth_requestAccounts(this.accounts))
       default:
-        throw new Error(`Method not supported: ${JSON.stringify(x)}`)
+        throw new Error(`Method not supported on mock: ${JSON.stringify(x)}`)
     }
   }
 

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.json",
   "include": ["./src"],
   "compilerOptions": {
-    "jsx": "react",
     "outDir": "./dist"
   }
 }

--- a/packages/eip1193/src/index.spec.ts
+++ b/packages/eip1193/src/index.spec.ts
@@ -1,10 +1,10 @@
 import { Eip1193Bridge } from '@ethersproject/experimental'
 import { Web3Provider } from '@ethersproject/providers'
 import { createWeb3ReactStoreAndActions } from '@web3-react/store'
+import { MockEIP1193Provider } from '@web3-react/core'
 import type { Actions, ProviderRpcError, RequestArguments, Web3ReactStore } from '@web3-react/types'
 import { EventEmitter } from 'node:events'
 import { EIP1193 } from '.'
-import { MockEIP1193Provider } from './mock'
 
 class MockProviderRpcError extends Error {
   public code: number

--- a/packages/eip1193/tsconfig.json
+++ b/packages/eip1193/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["./src"],
+  "include": ["./src", "../core/src/mockProvider.ts"],
   "compilerOptions": {
     "outDir": "./dist"
   }

--- a/packages/eip1193/tsconfig.json
+++ b/packages/eip1193/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["./src", "../core/src/mockProvider.ts"],
+  "include": ["./src"],
   "compilerOptions": {
     "outDir": "./dist"
   }

--- a/packages/metamask/src/index.spec.ts
+++ b/packages/metamask/src/index.spec.ts
@@ -1,7 +1,7 @@
 import { createWeb3ReactStoreAndActions } from '@web3-react/store'
 import type { Actions, Web3ReactStore } from '@web3-react/types'
 import { MetaMask } from '.'
-import { MockEIP1193Provider } from '../../eip1193/src/mock'
+import { MockEIP1193Provider } from '@web3-react/core'
 
 const chainId = '0x1'
 const accounts: string[] = ['0x0000000000000000000000000000000000000000']

--- a/packages/walletconnect-v2/src/index.spec.ts
+++ b/packages/walletconnect-v2/src/index.spec.ts
@@ -17,6 +17,9 @@ const createTestEnvironment = (opts: Omit<WalletConnectOptions, 'projectId'>) =>
 const accounts = ['0x0000000000000000000000000000000000000000']
 const chains = [1, 2, 3]
 
+/*
+ * TODO: Move this to `@web3-react/types` and further narrow down types for `RequestArguments` 
+ */
 type SwitchEthereumChainRequestArguments = {
   method: 'wallet_switchEthereumChain',
   params: [{ chainId: string }]

--- a/packages/walletconnect-v2/src/index.spec.ts
+++ b/packages/walletconnect-v2/src/index.spec.ts
@@ -31,17 +31,13 @@ const isSwitchEthereumChainRequest = (x: RequestArguments): x is SwitchEthereumC
 }
 
 class MockWalletConnectProvider extends MockEIP1193Provider<number> {
-  public eth_switchEthereumChain = jest.fn((args: string) => args)
+  /** per {@link https://eips.ethereum.org/EIPS/eip-3326#specification EIP-3326} */
+  public eth_switchEthereumChain = jest.fn((args: string) => null)
 
   public request(x: RequestArguments | SwitchEthereumChainRequestArguments): Promise<unknown> {
-    /*
-     * Switches active chain and returns `null` to indicate success
-     * https://eips.ethereum.org/EIPS/eip-3326#specification
-     */
     if (isSwitchEthereumChainRequest(x)) {
       this.chainId = parseInt(x.params[0].chainId, 16)
-      this.eth_switchEthereumChain(JSON.stringify(x))
-      return Promise.resolve(null)
+      return Promise.resolve(this.eth_switchEthereumChain(JSON.stringify(x)))
     } else {
       return super.request(x)
     }

--- a/packages/walletconnect-v2/src/index.spec.ts
+++ b/packages/walletconnect-v2/src/index.spec.ts
@@ -1,11 +1,9 @@
-// Not avaiable in the `node` environment, but required by WalletConnect
 global.TextEncoder = jest.fn()
 global.TextDecoder = jest.fn()
 
-// We are not using Web3Modal and it is not available in the `node` environment either
-jest.mock('@web3modal/standalone', () => ({ Web3Modal: jest.fn().mockImplementation() }))
-
 import { createWeb3ReactStoreAndActions } from '@web3-react/store'
+import { MockEIP1193Provider } from '@web3-react/core'
+import { RequestArguments } from '@web3-react/types'
 import { EthereumProvider } from '@walletconnect/ethereum-provider'
 
 import { WalletConnect, WalletConnectOptions } from '.'
@@ -19,38 +17,61 @@ const createTestEnvironment = (opts: Omit<WalletConnectOptions, 'projectId'>) =>
 const accounts = ['0x0000000000000000000000000000000000000000']
 const chains = [1, 2, 3]
 
+type SwitchEthereumChainRequestArguments = {
+  method: 'wallet_switchEthereumChain',
+  params: [{ chainId: string }]
+}
+
+const isSwitchEthereumChainRequest = (x: RequestArguments): x is SwitchEthereumChainRequestArguments => {
+  return x.method === 'wallet_switchEthereumChain'
+}
+
+class MockWalletConnectProvider extends MockEIP1193Provider<number> {
+  public eth_switchEthereumChain = jest.fn((args: string) => args)
+
+  public request(x: RequestArguments | SwitchEthereumChainRequestArguments): Promise<unknown> {
+    /*
+     * Switches active chain and returns `null` to indicate success
+     * https://eips.ethereum.org/EIPS/eip-3326#specification
+     */
+    if (isSwitchEthereumChainRequest(x)) {
+      const chainId = x.params[0].chainId
+      if (!chainId) {
+        throw new Error('Invalid request, missing `chainId`')
+      }
+      this.chainId = parseInt(chainId, 16)
+      this.eth_switchEthereumChain(JSON.stringify(x))
+      return Promise.resolve(null)
+    } else {
+      return super.request(x)
+    }
+  }
+
+  public enable() {
+    return super.request({ method: 'eth_requestAccounts' })
+  }
+
+  // session is an object when connected, undefined otherwise
+  get session() {
+    return this.eth_requestAccounts.mock.calls.length > 0 ? {} : undefined
+  }
+}
+
 describe('WalletConnect', () => {
-  const wc2RequestMock = jest.fn()
   let wc2InitMock: jest.Mock
 
   beforeEach(() => {
-    const wc2EnableMock = jest.fn().mockResolvedValue(accounts)
+    /*
+     * TypeScript error is expected here. We're mocking a factory `init` method
+     * to only define a subset of `EthereumProvider` that we use internally
+     */
     // @ts-ignore
-    // TypeScript error is expected here. We're mocking a factory `init` method
-    // to only define a subset of `EthereumProvider` that we use internally
-    wc2InitMock = jest.spyOn(EthereumProvider, 'init').mockImplementation(async (opts) => ({
-      // we read this in `enable` to get current chain 
-      accounts,
-      chainId: opts.chains[0],
-      // session is an object when connected, undefined otherwise
-      get session() {
-        return wc2EnableMock.mock.calls.length > 0 ? {} : undefined
-      },
-      // methods used in `activate` and `isomorphicInitialize`
-      enable: wc2EnableMock,
-      // mock EIP-1193
-      request: wc2RequestMock,
-      on() {
-        return this
-      },
-      removeListener() {
-        return this
-      },
-    }))
-  })
-
-  afterEach(() => {
-    wc2RequestMock.mockReset()
+    wc2InitMock = jest.spyOn(EthereumProvider, 'init').mockImplementation(async (opts) => {
+      const provider = new MockWalletConnectProvider()
+      provider.chainId = opts.chains[0]
+      provider.accounts = accounts
+      return provider
+    })
   })
 
   describe('#connectEagerly', () => {
@@ -62,7 +83,7 @@ describe('WalletConnect', () => {
 
   describe(`#isomorphicInitialize`, () => {
     test('should initialize exactly one provider and return a Promise if pending initialization', async () => {
-      const {connector, store} = createTestEnvironment({ chains })
+      const {connector} = createTestEnvironment({ chains })
       connector.activate()
       connector.activate()
       expect(wc2InitMock).toHaveBeenCalledTimes(1)
@@ -82,9 +103,9 @@ describe('WalletConnect', () => {
     })
 
     test('should activate passed chain', async () => {
-      const {connector, store} = createTestEnvironment({ chains })
+      const {connector} = createTestEnvironment({ chains })
       await connector.activate(2)
-      expect(store.getState().chainId).toEqual(2)
+      expect(connector.provider?.chainId).toEqual(2)
     })
     
     test('should throw an error for invalid chain', async () => {
@@ -95,15 +116,16 @@ describe('WalletConnect', () => {
     test('should switch chain if already connected', async () => {
       const {connector} = createTestEnvironment({ chains })
       await connector.activate()
+      expect(connector.provider?.chainId).toEqual(1)
       await connector.activate(2)
-      expect(wc2RequestMock).toHaveBeenCalledWith({ method: 'wallet_switchEthereumChain', params: [{ chainId: '0x2' }] })
+      expect(connector.provider?.chainId).toEqual(2)
     })
     
     test('should not switch chain if already connected', async () => {
       const {connector} = createTestEnvironment({ chains })
       await connector.activate(2)
       await connector.activate(2)
-      expect(wc2RequestMock).toBeCalledTimes(0)
+      expect((connector.provider as unknown as MockWalletConnectProvider).eth_switchEthereumChain).toBeCalledTimes(0)
     })
   })
 })

--- a/packages/walletconnect-v2/src/index.spec.ts
+++ b/packages/walletconnect-v2/src/index.spec.ts
@@ -39,11 +39,7 @@ class MockWalletConnectProvider extends MockEIP1193Provider<number> {
      * https://eips.ethereum.org/EIPS/eip-3326#specification
      */
     if (isSwitchEthereumChainRequest(x)) {
-      const chainId = x.params[0].chainId
-      if (!chainId) {
-        throw new Error('Invalid request, missing `chainId`')
-      }
-      this.chainId = parseInt(chainId, 16)
+      this.chainId = parseInt(x.params[0].chainId, 16)
       this.eth_switchEthereumChain(JSON.stringify(x))
       return Promise.resolve(null)
     } else {

--- a/packages/walletconnect-v2/src/index.spec.ts
+++ b/packages/walletconnect-v2/src/index.spec.ts
@@ -1,3 +1,4 @@
+// Not avaiable in the `node` environment, but required by WalletConnect
 global.TextEncoder = jest.fn()
 global.TextDecoder = jest.fn()
 

--- a/packages/walletconnect/src/index.spec.ts
+++ b/packages/walletconnect/src/index.spec.ts
@@ -4,13 +4,7 @@ import EventEmitter from 'node:events'
 import { WalletConnect } from '.'
 import { MockEIP1193Provider } from '@web3-react/core'
 
-/**
- * Creating a WalletConnect specific mock is required because it returns
- * `chainId` as a number instead of a string. 
- */
 class MockWalletConnectProvider extends MockEIP1193Provider<number> {
-  public connector = new EventEmitter()
-
   /**
    * TODO(INFRA-140): We're using the following private API to fix an underlying WalletConnect issue.
    * See {@link WalletConnect.activate} for details.

--- a/packages/walletconnect/src/index.spec.ts
+++ b/packages/walletconnect/src/index.spec.ts
@@ -2,23 +2,14 @@ import { createWeb3ReactStoreAndActions } from '@web3-react/store'
 import type { Actions, RequestArguments, Web3ReactStore } from '@web3-react/types'
 import EventEmitter from 'node:events'
 import { WalletConnect } from '.'
-import { MockEIP1193Provider } from '../../eip1193/src/mock'
+import { MockEIP1193Provider } from '@web3-react/core'
 
-// necessary because walletconnect returns chainId as a number
-class MockMockWalletConnectProvider extends MockEIP1193Provider {
+/**
+ * Creating a WalletConnect specific mock is required because it returns
+ * `chainId` as a number instead of a string. 
+ */
+class MockWalletConnectProvider extends MockEIP1193Provider<number> {
   public connector = new EventEmitter()
-
-  public eth_chainId_number = jest.fn((chainId?: string) =>
-    chainId === undefined ? chainId : Number.parseInt(chainId, 16)
-  )
-
-  public request(x: RequestArguments): Promise<unknown> {
-    if (x.method === 'eth_chainId') {
-      return Promise.resolve(this.eth_chainId_number(this.chainId))
-    } else {
-      return super.request(x)
-    }
-  }
 
   /**
    * TODO(INFRA-140): We're using the following private API to fix an underlying WalletConnect issue.
@@ -27,15 +18,15 @@ class MockMockWalletConnectProvider extends MockEIP1193Provider {
   private setHttpProvider() {}
 }
 
-jest.mock('@walletconnect/ethereum-provider', () => MockMockWalletConnectProvider)
+jest.mock('@walletconnect/ethereum-provider', () => MockWalletConnectProvider)
 
-const chainId = '0x1'
+const chainId = 1
 const accounts: string[] = []
 
 describe('WalletConnect', () => {
   let store: Web3ReactStore
   let connector: WalletConnect
-  let mockProvider: MockMockWalletConnectProvider
+  let mockProvider: MockWalletConnectProvider
 
   describe('works', () => {
     beforeEach(async () => {
@@ -47,7 +38,7 @@ describe('WalletConnect', () => {
     test('#activate', async () => {
       await connector.connectEagerly().catch(() => {})
 
-      mockProvider = connector.provider as unknown as MockMockWalletConnectProvider
+      mockProvider = connector.provider as unknown as MockWalletConnectProvider
       mockProvider.chainId = chainId
       mockProvider.accounts = accounts
 
@@ -55,12 +46,12 @@ describe('WalletConnect', () => {
 
       expect(mockProvider.eth_requestAccounts).toHaveBeenCalled()
       expect(mockProvider.eth_accounts).not.toHaveBeenCalled()
-      expect(mockProvider.eth_chainId_number).toHaveBeenCalled()
-      expect(mockProvider.eth_chainId_number.mock.invocationCallOrder[0])
+      expect(mockProvider.eth_chainId).toHaveBeenCalled()
+      expect(mockProvider.eth_chainId.mock.invocationCallOrder[0])
         .toBeGreaterThan(mockProvider.eth_requestAccounts.mock.invocationCallOrder[0])
 
       expect(store.getState()).toEqual({
-        chainId: Number.parseInt(chainId, 16),
+        chainId,
         accounts,
         activating: false,
         error: undefined,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "module": "CommonJS",
     "declaration": true,
-    "moduleResolution": "Node"
+    "moduleResolution": "Node",
+    "jsx": "react"
   },
   "exclude": ["**/*.spec.ts"]
 }


### PR DESCRIPTION
Updates some test suites, mostly WC2 by removing custom provider and re-using existing one. Also, makes it generic, so that it accepts both number and string, making implementation of wc test suite much smaller.