### PR TITLE
chore: ensure Eip1193 test suite has mocks that implement all properties of `ProviderRpcError`

### DIFF
--- a/packages/eip1193/src/index.spec.ts
+++ b/packages/eip1193/src/index.spec.ts
@@ -2,10 +2,10 @@ import { Eip1193Bridge } from '@ethersproject/experimental'
 import { Web3Provider } from '@ethersproject/providers'
 import { createWeb3ReactStoreAndActions } from '@web3-react/store'
 import { MockEIP1193Provider } from '@web3-react/core'
-import type { Actions, Web3ReactStore } from '@web3-react/types'
+import type { Actions, Web3ReactStore, ProviderRpcError } from '@web3-react/types'
 import { EIP1193 } from '.'
 
-class MockProviderRpcError extends Error {
+class MockProviderRpcError extends Error implements ProviderRpcError {
   public code: number
   constructor() {
     super('Mock Provider RPC Error')


### PR DESCRIPTION
As per discussion here: https://github.com/Uniswap/web3-react/pull/792#discussion_r1158521514