### PR TITLE
chore: remove todo from WC2 test suite

### DIFF
--- a/packages/eip1193/src/index.spec.ts
+++ b/packages/eip1193/src/index.spec.ts
@@ -2,10 +2,10 @@ import { Eip1193Bridge } from '@ethersproject/experimental'
 import { Web3Provider } from '@ethersproject/providers'
 import { createWeb3ReactStoreAndActions } from '@web3-react/store'
 import { MockEIP1193Provider } from '@web3-react/core'
-import type { Actions, Web3ReactStore } from '@web3-react/types'
+import type { Actions, Web3ReactStore, ProviderRpcError } from '@web3-react/types'
 import { EIP1193 } from '.'
 
-class MockProviderRpcError extends Error {
+class MockProviderRpcError extends Error implements ProviderRpcError {
   public code: number
   constructor() {
     super('Mock Provider RPC Error')

--- a/packages/eip1193/src/index.spec.ts
+++ b/packages/eip1193/src/index.spec.ts
@@ -2,10 +2,10 @@ import { Eip1193Bridge } from '@ethersproject/experimental'
 import { Web3Provider } from '@ethersproject/providers'
 import { createWeb3ReactStoreAndActions } from '@web3-react/store'
 import { MockEIP1193Provider } from '@web3-react/core'
-import type { Actions, Web3ReactStore, ProviderRpcError } from '@web3-react/types'
+import type { Actions, Web3ReactStore } from '@web3-react/types'
 import { EIP1193 } from '.'
 
-class MockProviderRpcError extends Error implements ProviderRpcError {
+class MockProviderRpcError extends Error {
   public code: number
   constructor() {
     super('Mock Provider RPC Error')

--- a/packages/walletconnect-v2/src/index.spec.ts
+++ b/packages/walletconnect-v2/src/index.spec.ts
@@ -18,9 +18,6 @@ const createTestEnvironment = (opts: Omit<WalletConnectOptions, 'projectId'>) =>
 const accounts = ['0x0000000000000000000000000000000000000000']
 const chains = [1, 2, 3]
 
-/*
- * TODO: Move this to `@web3-react/types` and further narrow down types for `RequestArguments` 
- */
 type SwitchEthereumChainRequestArguments = {
   method: 'wallet_switchEthereumChain',
   params: [{ chainId: string }]

--- a/packages/walletconnect-v2/src/index.spec.ts
+++ b/packages/walletconnect-v2/src/index.spec.ts
@@ -18,6 +18,9 @@ const createTestEnvironment = (opts: Omit<WalletConnectOptions, 'projectId'>) =>
 const accounts = ['0x0000000000000000000000000000000000000000']
 const chains = [1, 2, 3]
 
+/*
+ * TODO: Move this to `@web3-react/types` and further narrow down types for `RequestArguments` 
+ */
 type SwitchEthereumChainRequestArguments = {
   method: 'wallet_switchEthereumChain',
   params: [{ chainId: string }]


### PR DESCRIPTION
This was result of my misunderstanding of the `Provider` type. We should not narrow it down because it's mostly used in abstract class `Provider` and not directly interacted with. Most of the time, you're calling `request` off WalletConnect/MetaMask/GnosisSafe providers, and they have their own types. This is an exception for Eip1193, but this is not what the original intention of this todo was.

