### PR TITLE
build: Snyk ignore policy for unreachable/false-positive reported vulnerabilities 

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,6 +1,48 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
 version: v1.25.0
-ignore: {}
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-JS-SEMVER-3247795:
+    - '*':
+        reason: >-
+          lerna is fine with this version and vulnerability path is not
+          reachable
+        expires: 2023-08-06T16:52:38.439Z
+        created: 2023-07-07T16:52:38.448Z
+  SNYK-JS-NWSAPI-2841516:
+    - '*':
+        reason: >-
+          no direct update or patch available suggested for jest / most probably
+          vuln is not reachable
+        expires: 2023-08-06T16:54:16.219Z
+        created: 2023-07-07T16:54:16.233Z
+  SNYK-JS-TOUGHCOOKIE-5672873:
+    - '*':
+        reason: no patch or suggestion is available by jest
+        expires: 2023-08-06T16:55:11.239Z
+        created: 2023-07-07T16:55:11.253Z
+  SNYK-JS-WORDWRAP-3149973:
+    - '*':
+        reason: >-
+          ReDoS is valid when there is a path between the source (user
+          uncontrolled input) to a sink that is a regex parser but in this case
+          is not applicable
+        expires: 2023-08-06T16:56:21.700Z
+        created: 2023-07-07T16:56:21.716Z
+  'snyk:lic:npm:rlp:MPL-2.0':
+    - '*':
+        reason: >-
+          introduced through Coinbase Wallet and should be discussed with them -
+          MPL 2.0
+        expires: 2023-08-06T16:57:10.898Z
+        created: 2023-07-07T16:57:10.915Z
+  'snyk:lic:npm:ethereumjs-util:MPL-2.0':
+    - '*':
+        reason: >-
+          introduced through Coinbase Wallet and should be discussed with them -
+          MPL 2.0
+        expires: 2023-08-06T16:57:55.493Z
+        created: 2023-07-07T16:57:55.512Z
 patch: {}
 exclude:
   global:


### PR DESCRIPTION
### Description
Snyk reported vulnerabilities recently that have no direct upgrade yet or were false-positive. We just updated the `lerna` to major version `^5.0.0`

### Tasks
- [x] Ignored until `2024-01-01` as no viable patch or suggestion is available. Plus, the reported vulnerabilities were false-positive. 
- [x] MPL-2 license issue introduced through Coinbase Wallet should be reported to them.  
---
```
 snyk ignore --id='SNYK-JS-NWSAPI-2841516' --expirty='2024-01-01' --reason='no direct update or patch available suggested for jest / most probably vuln is not reachable'
 snyk ignore --id='SNYK-JS-TOUGHCOOKIE-5672873' --expirty='2024-01-01' --reason='no patch or suggestion is available by jest'
 snyk ignore --id='SNYK-JS-WORDWRAP-3149973' --expirty='2024-01-01' --reason='ReDoS is valid when there is a path between the source (user uncontrolled input) to a sink that is a regex parser but in this case is not applicable'
 snyk ignore --id='snyk:lic:npm:rlp:MPL-2.0' --expirty='2024-01-01' --reason='introduced through Coinbase Wallet and should be discussed with them - MPL 2.0'
 snyk ignore --id='snyk:lic:npm:ethereumjs-util:MPL-2.0' --expirty='2024-01-01' --reason='introduced through Coinbase Wallet and should be discussed with them - MPL 2.0'
``` 
### How Has This Been Tested?
Running `snyk test` locally to ensure the `.ignore` file and policies works.

```shell
➜  web3-react git:(build/snyk-ignore) snyk test --dev

Testing /Users/mohsen.ahmadi/web3-react...

Organization:      uniswap-poc
Package manager:   yarn
Target file:       yarn.lock
Project name:      web3-react
Open source:       no
Project path:      /Users/mohsen.ahmadi/web3-react
Local Snyk policy: found
Licenses:          enabled

✔ Tested 1059 dependencies for known issues, no vulnerable paths found.

```

