### PR TITLE
Fix zustand warning

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@web3-react/store": "^8.2.0",
     "@web3-react/types": "^8.2.0",
-    "zustand": "^4.3.5"
+    "zustand": "4.4.0"
   },
   "peerDependencies": {
     "react": ">=16.8"

--- a/packages/core/src/hooks.ts
+++ b/packages/core/src/hooks.ts
@@ -3,6 +3,7 @@ import type { BaseProvider, Web3Provider } from '@ethersproject/providers'
 import { createWeb3ReactStoreAndActions } from '@web3-react/store'
 import type { Actions, Connector, Web3ReactState, Web3ReactStore } from '@web3-react/types'
 import { useEffect, useMemo, useState } from 'react'
+import { createWithEqualityFn } from 'zustand/traditional'
 import { useStore } from 'zustand'
 
 let DynamicProvider: typeof Web3Provider | null | undefined
@@ -260,7 +261,7 @@ function getStateHooks(store: Web3ReactStore) {
   }
 
   function useAccounts(): Web3ReactState['accounts'] {
-    return useStore(store, ACCOUNTS, ACCOUNTS_EQUALITY_CHECKER)
+    return createWithEqualityFn(store, ACCOUNTS_EQUALITY_CHECKER)(ACCOUNTS)
   }
 
   function useIsActivating(): Web3ReactState['activating'] {

--- a/packages/core/src/hooks.ts
+++ b/packages/core/src/hooks.ts
@@ -3,7 +3,7 @@ import type { BaseProvider, Web3Provider } from '@ethersproject/providers'
 import { createWeb3ReactStoreAndActions } from '@web3-react/store'
 import type { Actions, Connector, Web3ReactState, Web3ReactStore } from '@web3-react/types'
 import { useEffect, useMemo, useState } from 'react'
-import { createWithEqualityFn } from 'zustand/traditional'
+import { useStoreWithEqualityFn } from 'zustand/traditional'
 import { useStore } from 'zustand'
 
 let DynamicProvider: typeof Web3Provider | null | undefined
@@ -261,7 +261,7 @@ function getStateHooks(store: Web3ReactStore) {
   }
 
   function useAccounts(): Web3ReactState['accounts'] {
-    return createWithEqualityFn(store, ACCOUNTS_EQUALITY_CHECKER)(ACCOUNTS)
+    return useStoreWithEqualityFn(store, ACCOUNTS, ACCOUNTS_EQUALITY_CHECKER)
   }
 
   function useIsActivating(): Web3ReactState['activating'] {

--- a/packages/core/src/hooks.ts
+++ b/packages/core/src/hooks.ts
@@ -3,8 +3,8 @@ import type { BaseProvider, Web3Provider } from '@ethersproject/providers'
 import { createWeb3ReactStoreAndActions } from '@web3-react/store'
 import type { Actions, Connector, Web3ReactState, Web3ReactStore } from '@web3-react/types'
 import { useEffect, useMemo, useState } from 'react'
-import { useStoreWithEqualityFn } from 'zustand/traditional'
 import { useStore } from 'zustand'
+import { useStoreWithEqualityFn } from 'zustand/traditional'
 
 let DynamicProvider: typeof Web3Provider | null | undefined
 async function importProvider(): Promise<void> {

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -25,6 +25,6 @@
   "dependencies": {
     "@ethersproject/address": "^5",
     "@web3-react/types": "^8.2.0",
-    "zustand": "^4.3.5"
+    "zustand": "4.4.0"
   }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -23,6 +23,6 @@
     "start": "tsc --watch"
   },
   "dependencies": {
-    "zustand": "^4.3.5"
+    "zustand": "4.4.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10115,9 +10115,9 @@ yargs@^17.6.2:
     y18n "^5.0.5"
     yargs-parser "^21.1.1"
 
-zustand@^4.3.5:
-  version "4.3.6"
-  resolved "https://registry.yarnpkg.com/zustand/-/zustand-4.3.6.tgz#ce7804eb75361af0461a2d0536b65461ec5de86f"
-  integrity sha512-6J5zDxjxLE+yukC2XZWf/IyWVKnXT9b9HUv09VJ/bwGCpKNcaTqp7Ws28Xr8jnbvnZcdRaidztAPsXFBIqufiw==
+zustand@4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-4.4.0.tgz#13b3e8ca959dd53d536034440aec382ff91b65c3"
+  integrity sha512-2dq6wq4dSxbiPTamGar0NlIG/av0wpyWZJGeQYtUOLegIUvhM2Bf86ekPlmgpUtS5uR7HyetSiktYrGsdsyZgQ==
   dependencies:
     use-sync-external-store "1.2.0"


### PR DESCRIPTION
Fixes https://github.com/Uniswap/web3-react/issues/871

Built successfully


Since 4.4.0, Zustand's dev deprecated the use of useStore() with an equality function.